### PR TITLE
encode characters in package name

### DIFF
--- a/lib/purl/composer.ex
+++ b/lib/purl/composer.ex
@@ -22,8 +22,8 @@ defmodule Purl.Composer do
           [type | encode_namespace(namespace)] ++
             [
               case version do
-                nil -> name
-                version -> "#{name}@#{encode_version(version)}"
+                nil -> encode_name(name)
+                version -> "#{encode_name(name)}@#{encode_version(version)}"
               end
             ],
           "/"
@@ -44,6 +44,11 @@ defmodule Purl.Composer do
     Enum.map(namespace, fn namespace_segment ->
       URI.encode(namespace_segment, &(&1 != ?@ and URI.char_unescaped?(&1)))
     end)
+  end
+
+  @spec encode_name(name :: Purl.name()) :: [String.t()]
+  defp encode_name(name) do
+    URI.encode(name, &(&1 != ?@ and URI.char_unescaped?(&1)))
   end
 
   @spec encode_qualifiers(qualifiers :: Purl.qualifiers()) :: String.t()

--- a/lib/purl/parser.ex
+++ b/lib/purl/parser.ex
@@ -95,7 +95,7 @@ defmodule Purl.Parser do
 
         {name, version} =
           case String.split(name, "@", parts: 2) do
-            [name, version] -> {name, URI.decode(version)}
+            [name, version] -> {URI.decode(name), URI.decode(version)}
             [name] -> {name, nil}
           end
 


### PR DESCRIPTION
I haven't checked if this causes any other problems, but this fixes #10, at least for the package `pkg:maven/net.databinder/dispatch-http%252Bjson_2.7.3@0.6.0`. I hadn't noticed before that the name wasn't being encoded correctly on write, but that should be fixed too.